### PR TITLE
fix panic from newGoValue when the notification value is nil

### DIFF
--- a/value.go
+++ b/value.go
@@ -71,7 +71,10 @@ func (v value) String() string {
 }
 
 func newGoValue(cRef *C.Value) *value {
-	return &value{cRef}
+	if cRef != nil {
+		return &value{cRef}
+	}
+	return nil
 }
 
 func (v *value) notify(api *api, nt *notification) {


### PR DESCRIPTION
Because of commit 86e99ed sometimes the ValueID for a notification is nil. Whenever a nil valueID is passed to the function newGoValue() It panics since it cannot assign it to the ValueID struct. All this PR does is check if the value is nil before assigning it to the struct. 
