### PR TITLE
Added AddNode handler to trigger listening for addition of new nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-*note: this fork of go-openzwave will add support for new node discovery to the go-openzwave library. This message will be removed when adding this support is successful*
-
 go-openzwave
 ============
 A minimal 'Go' binding to the C++ openzwave library.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+*note: this fork of go-openzwave will add support for new node discovery to the go-openzwave library. This message will be removed when adding this support is successful*
+
 go-openzwave
 ============
 A minimal 'Go' binding to the C++ openzwave library.

--- a/api.go
+++ b/api.go
@@ -47,6 +47,10 @@ type API interface {
 	// the API logger
 	Logger() Logger
 
+	// Get a network by HomeID
+	// Returns network, or nil if no network exists matching the specified HomeID
+	GetNetwork(homeId uint32) Network
+
 	// Shutdown the event loop
 	Shutdown(exit int)
 }
@@ -92,6 +96,14 @@ func (a *api) QuitSignal() chan int {
 
 func (a *api) Logger() Logger {
 	return a.logger
+}
+
+func (a *api) GetNetwork(homeId uint32) Network {
+	net, ok := a.networks[homeId]
+	if !ok {
+		return nil
+	}
+	return net
 }
 
 func (a *api) getNetwork(homeId uint32) *network {

--- a/api/manager.h
+++ b/api/manager.h
@@ -1,4 +1,5 @@
 extern void startManager(API * api);
 extern void stopManager(API * api);
+extern bool addNode(uint32 homeId, bool secure);
 extern bool addDriver(char * device);
 extern bool removeDriver(char * device);

--- a/manager.cpp
+++ b/manager.cpp
@@ -19,6 +19,10 @@ void stopManager(API * api)
   OpenZWave::Manager::Destroy();
 }
 
+bool addNode(uint32 homeId, bool secure) {
+  return OpenZWave::Manager::Get()->AddNode(homeId, secure);
+}
+
 bool addDriver(char * device)
 {
   return OpenZWave::Manager::Get()->AddDriver(device);

--- a/network.go
+++ b/network.go
@@ -1,5 +1,10 @@
 package openzwave
 
+// #cgo LDFLAGS: -lopenzwave -Lgo/src/github.com/ninjasphere/go-openzwave/openzwave
+// #cgo CPPFLAGS: -Iopenzwave/cpp/src
+// #include "api.h"
+import "C"
+
 import (
 	"github.com/ninjasphere/go-openzwave/NT"
 )
@@ -12,6 +17,10 @@ const (
 type Network interface {
 	// the identifier of the home network
 	GetHomeId() uint32
+	// tell the controller to allow new nodes to register
+	// Secure: try to register securely
+	// returns true if the registration request succeeded
+	AddNode(secure bool) bool
 }
 
 type network struct {
@@ -25,6 +34,10 @@ func newNetwork(homeId uint32) *network {
 
 func (nw *network) GetHomeId() uint32 {
 	return nw.homeId
+}
+
+func (nw *network) AddNode(secure bool) bool {
+	return bool(C.addNode(C.uint32(nw.GetHomeId()), C.bool(secure)))
 }
 
 func (nw *network) notify(api *api, nt *notification) {


### PR DESCRIPTION
Added support for handling of Manager::AddNode in the openzwave library, so that go-openzwave may trigger the controller to allow addition of new nodes to the network.